### PR TITLE
Abusive modification of documents when obtaining a shortURL #30

### DIFF
--- a/application-urlshortener-default/src/main/java/com/xwiki/urlshortener/internal/rest/DefaultURLShortenerResource.java
+++ b/application-urlshortener-default/src/main/java/com/xwiki/urlshortener/internal/rest/DefaultURLShortenerResource.java
@@ -124,7 +124,7 @@ public class DefaultURLShortenerResource implements URLShortenerResource
 
         if (authorization.hasAccess(Right.VIEW, documentReference)) {
             XWikiDocument currentDoc = xcontext.getWiki().getDocument(documentReference, xcontext);
-            String pageID = addURLShortenerXObject(currentDoc);
+            String pageID = addURLShortenerXObject(currentDoc.clone());
             if (pageID == null || pageID.isEmpty()) {
                 throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
             }

--- a/application-urlshortener-default/src/test/java/com/xwiki/urlshortener/internal/rest/DefaultURLShortenerResourceTest.java
+++ b/application-urlshortener-default/src/test/java/com/xwiki/urlshortener/internal/rest/DefaultURLShortenerResourceTest.java
@@ -134,6 +134,7 @@ public class DefaultURLShortenerResourceTest
     {
         when(xcontextProvider.get()).thenReturn(xcontext);
         when(xcontext.getWiki()).thenReturn(xwiki);
+        when(document.clone()).thenReturn(document);
     }
 
     /**

--- a/application-urlshortener-ui/src/main/resources/URLShortener/Code/UI.xml
+++ b/application-urlshortener-ui/src/main/resources/URLShortener/Code/UI.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.5" reference="URLShortener.Code.UI" locale="">
+<xwikidoc version="1.6" reference="URLShortener.Code.UI" locale="">
   <web>URLShortener.Code</web>
   <name>UI</name>
   <language/>
@@ -141,16 +141,24 @@ require(['jquery', 'xwiki-meta', 'xwiki-l10n!urlshortener-messages'], function($
       'currentDocRef': XWiki.Model.serialize(xm.documentReference)
     });
     const computeIDURL = baseURL + '/rest/p/create?' + params;
-    $.post(computeIDURL, params).done(response =&gt; {
-      // The wiki ID is needed only for subwikis, in order to be able to locate the resource after.
-      const wikiId = XWiki.currentWiki == XWiki.mainWiki ? '' : XWiki.currentWiki + '/';
-      const shortenedURL = baseURL + '/short/' + wikiId + response.pageID;
-      navigator.clipboard.writeText(shortenedURL).then(() =&gt; {
-        new XWiki.widgets.Notification(l10n['done'], 'done');
-      })
-    }).fail(error =&gt; {
-      console.log(error);
-      new XWiki.widgets.Notification(l10n['fail'], 'error');
+    $.ajax({
+      url: computeIDURL,
+      type: 'POST',
+      data: params,
+      contentType: 'application/json',
+      dataType: 'json',
+      success: function(response) {
+        // The wiki ID is needed only for subwikis, in order to be able to locate the resource after.
+        const wikiId = XWiki.currentWiki == XWiki.mainWiki ? '' : XWiki.currentWiki + '/';
+        const shortenedURL = baseURL + '/short/' + wikiId + response.pageID;
+        navigator.clipboard.writeText(shortenedURL).then(() =&gt; {
+          new XWiki.widgets.Notification(l10n['done'], 'done');
+        })
+      },
+      error: function(error) {
+        console.log(error);
+        new XWiki.widgets.Notification(l10n['fail'], 'error');
+      }
     });
   };
 
@@ -220,7 +228,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-l10n!urlshortener-messages'], function($
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/application-urlshortener-ui/src/main/resources/URLShortener/Code/UI.xml
+++ b/application-urlshortener-ui/src/main/resources/URLShortener/Code/UI.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.6" reference="URLShortener.Code.UI" locale="">
+<xwikidoc version="1.5" reference="URLShortener.Code.UI" locale="">
   <web>URLShortener.Code</web>
   <name>UI</name>
   <language/>
@@ -228,7 +228,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-l10n!urlshortener-messages'], function($
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>


### PR DESCRIPTION
To fix the abusive modification warning, all I did was clone the original document, as mentioned in https://www.xwiki.org/xwiki/bin/view/ReleaseNotes/Data/XWiki/17.2.0RC1/#HProtectionagainstconcurrentmodificationofcacheddocument.

To fix the warning that was displayed when getting a short URL that was already created, I had to change the resourcetype from form-encoded to json (https://stackoverflow.com/questions/2011895/how-to-fix-jersey-post-request-parameters-warning). The root cause of the issue was fixed directly in Jersey in this PR: https://github.com/eclipse-ee4j/jersey/pull/5208.