### PR TITLE
Move the URLShortenerClass initialization in the default module #58

### DIFF
--- a/application-urlshortener-default/src/main/java/com/xwiki/urlshortener/internal/URLShortenerClassInitializer.java
+++ b/application-urlshortener-default/src/main/java/com/xwiki/urlshortener/internal/URLShortenerClassInitializer.java
@@ -1,0 +1,70 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.urlshortener.internal;
+
+import java.util.Arrays;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.LocalDocumentReference;
+
+import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
+import com.xpn.xwiki.objects.classes.BaseClass;
+
+/**
+ * Initializes the URLShortenerClass.
+ *
+ * @version $Id$
+ * @since 1.3.3
+ */
+@Component
+@Named(URLShortenerClassInitializer.CLASS_FULLNAME)
+@Singleton
+public class URLShortenerClassInitializer extends AbstractMandatoryClassInitializer
+{
+    /**
+     * The serialized full name of the class.
+     */
+    public static final String CLASS_FULLNAME = "URLShortener.Code.URLShortenerClass";
+
+    /**
+     * The reference of the class.
+     */
+    public static final LocalDocumentReference REFERENCE =
+        new LocalDocumentReference(Arrays.asList("URLShortener", "Code"), "URLShortenerClass");
+
+    private static final String PAGE_ID = "pageID";
+
+    /**
+     * Default constructor.
+     */
+    public URLShortenerClassInitializer()
+    {
+        super(REFERENCE, "URLShortener Class");
+    }
+
+    @Override
+    protected void createClass(BaseClass xclass)
+    {
+        xclass.addTextField(PAGE_ID, PAGE_ID, 30);
+    }
+}

--- a/application-urlshortener-default/src/main/resources/META-INF/components.txt
+++ b/application-urlshortener-default/src/main/resources/META-INF/components.txt
@@ -1,5 +1,6 @@
 com.xwiki.urlshortener.internal.rest.DefaultURLShortenerResource
 com.xwiki.urlshortener.internal.DefaultURLShortenerManager
+com.xwiki.urlshortener.internal.URLShortenerClassInitializer
 com.xwiki.urlshortener.internal.URLShortenerResourceReferenceHandler
 com.xwiki.urlshortener.internal.URLShortenerResourceReferenceResolver
 com.xwiki.urlshortener.internal.URLShortenerResourceReferenceSerializer


### PR DESCRIPTION
# Issue URL
#58 

# Changes

Created a document class initializer that creates the class automatically on extension upgrade/install.

# Screenshots & Video

I made sure that the class does not get changed when upgrading the app so we dont hit instances with a lot of shortened urls.

<img width="1271" height="481" alt="image" src="https://github.com/user-attachments/assets/7ad0dcfa-5a4d-41f9-bd08-db4b331c8397" />


# Executed Tests

No tests

* [ ] I checked the accessibility of this change (if you don't know what this is about or how to do it, leave this unchecked and don't worry)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
